### PR TITLE
fix(pricing): update snapshot feature listings across all plans

### DIFF
--- a/i18n/messages/en/index.json
+++ b/i18n/messages/en/index.json
@@ -137,7 +137,8 @@
           "bandwidth": "Up to 10mb/s bandwidth",
           "priority": "Low Priority Queue",
           "persistence": "No Persistence",
-          "idle": "5 Min Idle Timeout"
+          "idle": "5 Min Idle Timeout",
+          "snapshots": "Public Snapshots"
         },
         "cta": "Try for Free"
       },
@@ -151,6 +152,7 @@
           "bandwidth": "100mb/s bandwidth",
           "priority": "Standard Priority",
           "persistence": "20 GB persistence",
+          "snapshots": "Snapshot Creation",
           "api": "API Access"
         },
         "cta": "Get Started"
@@ -165,7 +167,7 @@
           "bandwidth": "150mb/s bandwidth",
           "priority": "High Priority Queue",
           "persistence": "40 GB persistence",
-          "snapshots": "Unlimited Snapshots",
+          "snapshots": "Snapshot Creation",
           "api": "API Access"
         },
         "cta": "Go Pro"
@@ -796,11 +798,11 @@
           "title": "Subscription Tiers",
           "free": {
             "name": "Free Tier:",
-            "description": "Provides limited access with 60-minute session limits, 1 vCPU, 1 GB RAM, no persistence, and low priority queue access. Intended for evaluation purposes only."
+            "description": "Provides limited access with 60-minute session limits, 1 vCPU, 1 GB RAM, no persistence, low priority queue access, and access to public snapshots. Snapshot creation is not available on this tier. Intended for evaluation purposes only."
           },
           "paid": {
             "name": "Paid Tiers (Lite, Pro, Power Tiers):",
-            "description": "Offer extended or unlimited session durations, increased computational resources, persistent storage with retention periods, high-priority queue access, API access, and unlimited snapshots (Pro and above). Credits are consumed based on active usage time."
+            "description": "Offer extended or unlimited session durations, increased computational resources, persistent storage with retention periods, high-priority queue access, API access, access to public snapshots, and snapshot creation (limits vary by tier). Credits are consumed based on active usage time."
           }
         },
         "billing": {

--- a/i18n/messages/es/index.json
+++ b/i18n/messages/es/index.json
@@ -138,7 +138,8 @@
           "bandwidth": "Hasta 10mb/s",
           "priority": "Prioridad baja",
           "persistence": "No se guarda nada",
-          "idle": "Se apaga a los 5 min sin uso"
+          "idle": "Se apaga a los 5 min sin uso",
+          "snapshots": "Snapshots Públicos"
         },
         "cta": "Probar gratis"
       },
@@ -152,6 +153,7 @@
           "bandwidth": "100mb/s",
           "priority": "Prioridad estándar",
           "persistence": "20 GB para guardar",
+          "snapshots": "Creación de Snapshots",
           "api": "Acceso a la API"
         },
         "cta": "Empezar"
@@ -166,7 +168,7 @@
           "bandwidth": "150mb/s",
           "priority": "Prioridad alta",
           "persistence": "40 GB para guardar",
-          "snapshots": "Snapshots ilimitados",
+          "snapshots": "Creación de Snapshots",
           "api": "Acceso a la API"
         },
         "cta": "Ir a Pro"
@@ -797,11 +799,11 @@
           "title": "Niveles de Suscripción",
           "free": {
             "name": "Nivel Gratuito:",
-            "description": "Proporciona acceso limitado con límites de sesión de 60 minutos, 1 vCPU, 1 GB RAM, sin persistencia y acceso a cola de baja prioridad. Destinado solo a fines de evaluación."
+            "description": "Proporciona acceso limitado con límites de sesión de 60 minutos, 1 vCPU, 1 GB RAM, sin persistencia, acceso a cola de baja prioridad y acceso a snapshots públicos. La creación de snapshots no está disponible en este nivel. Destinado solo a fines de evaluación."
           },
           "paid": {
             "name": "Niveles de Pago (Lite, Pro, Power):",
-            "description": "Ofrecen duraciones de sesión extendidas o ilimitadas, recursos computacionales aumentados, almacenamiento persistente con períodos de retención, acceso a cola de alta prioridad, acceso API y snapshots ilimitados (Pro en adelante). Los créditos se consumen según el tiempo de uso activo."
+            "description": "Ofrecen duraciones de sesión extendidas o ilimitadas, recursos computacionales aumentados, almacenamiento persistente con períodos de retención, acceso a cola de alta prioridad, acceso API, acceso a snapshots públicos y creación de snapshots (los límites varían según el nivel). Los créditos se consumen según el tiempo de uso activo."
           }
         },
         "billing": {


### PR DESCRIPTION
Free tier now shows "Public Snapshots", Lite and Pro show "Snapshot Creation". Terms of service updated to reflect public snapshot access for all tiers and per-tier creation limits.