### PR TITLE
Trim About Us page — cut fluff, keep facts

### DIFF
--- a/app/[locale]/about/page.tsx
+++ b/app/[locale]/about/page.tsx
@@ -31,13 +31,13 @@ export async function generateMetadata({ params: { locale } }: Props): Promise<M
 
   const title =
     locale === 'en'
-      ? 'About Cyqle: Multiplayer Cloud Desktop for Real-Time Collaboration'
-      : 'Acerca de Cyqle: Escritorio Cloud Multijugador para Colaboración en Tiempo Real';
+      ? 'About Cyqle: Multiplayer Cloud Desktop'
+      : 'Acerca de Cyqle: Escritorio Cloud Multijugador';
 
   const description =
     locale === 'en'
-      ? 'Built for teams tired of taking turns. Cyqle is a P2P cloud desktop where everyone types in parallel—multiple people, multiple keyboards, same machine. No more "can you see my screen?" Perfect for remote debugging, pair programming, and real-time collaboration.'
-      : 'Construido para equipos cansados de turnarse. Cyqle es un escritorio cloud P2P donde todos escriben en paralelo—múltiples personas, múltiples teclados, misma máquina. Se acabó el "¿ven mi pantalla?" Perfecto para depuración remota, programación en pareja y colaboración en tiempo real.';
+      ? 'Cyqle is a P2P cloud desktop where multiple people work on the same machine simultaneously. Each user gets their own cursor and keyboard. Spin up in seconds, collaborate in real time.'
+      : 'Cyqle es un escritorio cloud P2P donde varias personas trabajan en la misma máquina simultáneamente. Cada usuario tiene su propio cursor y teclado. Arranca en segundos, colaborá en tiempo real.';
 
   return {
     title,

--- a/i18n/messages/en/index.json
+++ b/i18n/messages/en/index.json
@@ -254,83 +254,81 @@
   },
   "aboutPage": {
     "hero": {
-      "title": "¿Who said the wheel shouldn't be reinvented?",
-      "subtitle": "The old one wasn't built for the cloud."
+      "title": "A Multiplayer Cloud Desktop",
+      "subtitle": "Same machine. Multiple keyboards. Everyone drives."
     },
     "problem": {
-      "badge": "The Friction",
-      "title": "Collaboration is Stuck in the 90s",
-      "intro": "Code lives in the cloud. Data lives in the cloud. But your actual work environment? It's still trapped on your local device.",
-      "scenario1": "Screen sharing is passive. One driver, many passengers. It's not collaboration; it's a presentation. You can't fix a bug you can't touch.",
-      "scenario2": "Local environments are fragile. You spend hours configuring a workspace that disappears when you close your laptop. Sharing it means explaining setup steps, not sending a link.",
-      "scenario3": "Compute is scattered. Your team has 10 powerful laptops but no shared infrastructure to swarm on a problem together.",
-      "truth": "We asked: What if the operating system itself was multiplayer? What if you could URL-share a full computer like a Google Doc?",
-      "solution": "Cyqle is the answer."
+      "badge": "The Problem",
+      "title": "Remote Work Still Means Taking Turns",
+      "intro": "Screen sharing is one driver, many watchers. That's not collaboration.",
+      "scenario1": "You can't touch the code on someone else's screen share. You just watch and describe what to type.",
+      "scenario2": "Local environments break, drift, and can't be shared with a link.",
+      "scenario3": "Your team has 10 laptops but no shared machine to work on together.",
+      "truth": "Operating systems were built for one user. We built one for many.",
+      "solution": "That's Cyqle."
     },
     "story": {
-      "badge": "Our Logic",
-      "title": "Why We Built It",
-      "year2017": "We started by building browser automation tools. Useful, but limited. We realized that automating a browser was only solving 10% of the problem.",
-      "pivot": "The real bottleneck was the Operating System.",
-      "year2025": "OSs, at their core, target a single end user. That's why screen sharing is so painful—it's a hack on top of a single-player architecture.",
-      "realization": "We decided to rebuild the desktop stack for p2p collaboration. No 'host' and 'guest'—just equal users working in parallel on the same machine.",
-      "present": "Cyqle is the result: A cloud computer that treats collaboration as a primitive, not a feature."
+      "badge": "Background",
+      "title": "How We Got Here",
+      "year2017": "We started in browser automation. Useful, but it only solved part of the problem.",
+      "pivot": "The bottleneck was the OS itself — built for a single user.",
+      "year2025": "Screen sharing is a hack on top of single-player architecture. That's why it's painful.",
+      "realization": "So we rebuilt the desktop for P2P. No host and guest — just equal users on the same machine.",
+      "present": "Cyqle is a cloud computer where collaboration is a core primitive."
     },
     "solution": {
-      "badge": "What It Actually Is",
-      "title": "A Full Linux Desktop That Doesn't Disappear",
-      "paragraph1": "Cyqle is a real Linux environment in the cloud. But instead of one person driving while others watch, everyone works simultaneously. Multiple people typing in parallel, each with their own cursor and window focus.",
-      "paragraph2": "It's not screen sharing. It's not a VM you SSH into alone. It's a genuinely multiplayer computer that you can spin up in seconds, collaborate on in real-time, then close—or persist and resume from any device.",
+      "badge": "What It Is",
+      "title": "A Full Linux Desktop, Shared in Real Time",
+      "paragraph1": "Cyqle is a real Linux environment in the cloud. Multiple people work simultaneously, each with their own cursor and keyboard input.",
+      "paragraph2": "Not screen sharing. Not a VM you SSH into alone. A multiplayer computer you spin up in seconds, work on together, then close or persist.",
       "realityCheck": "No more:",
       "painPoints": [
-        "\"Can you see my screen?\" (they're already there)",
-        "Describing bugs over chat (just invite them in)",
-        "\"It works on my machine\" (use the same machine)",
-        "Rebuilding demo environments (snapshot and reuse them)",
-        "Writing automation scripts for simple tasks (just record it)"
+        "\"Can you see my screen?\" — they're already there",
+        "Describing bugs over chat — just invite them in",
+        "\"It works on my machine\" — use the same machine",
+        "Rebuilding demo environments — snapshot and reuse",
+        "Writing scripts for simple tasks — record and replay"
       ]
     },
     "difference": {
       "badge": "Under the Hood",
-      "title": "Hard Engineering, Invisible to You",
-      "intro": "We solved the problems that made real-time cloud desktops impossible for years:",
+      "title": "What We Had to Solve",
+      "intro": "Real-time cloud desktops require solving hard problems:",
       "challenges": [
-        "Zero-latency P2P streaming (no central server lag)",
+        "P2P streaming with minimal latency (no central relay)",
         "System-level multi-cursor input injection",
-        "Cryptographically guaranteed ephemeral storage",
-        "Instant provisioning (sub-5-second boot times)",
-        "Browser-based access with native performance"
+        "Cryptographically erasable ephemeral storage",
+        "Sub-5-second boot times",
+        "Browser-based access at native performance"
       ],
-      "conclusion": "It's complex technology wrapping a simple promise: It just works."
+      "conclusion": "Complex infrastructure behind a simple experience."
     },
     "forWhom": {
       "badge": "Use Cases",
-      "title": "Build for Teams Who:",
+      "title": "Built for Teams Who:",
       "items": [
-        "Debug together, not sequentially",
-        "Need instant, disposable reproduction environments",
-        "Want to onboard engineers by doing, not documenting",
-        "Run browser automation without maintaining infrastructure",
-        "Hate the lag and friction of screen sharing",
-        "Need a secure sandbox for AI agent testing",
-        "Require root access without compromising local security",
-        "Value flow state over setup time"
+        "Debug together instead of taking turns",
+        "Need disposable reproduction environments",
+        "Onboard engineers hands-on, not with docs",
+        "Run browser automation without infra overhead",
+        "Need a secure sandbox for AI agents",
+        "Want root access without risking local machines"
       ]
     },
     "vision": {
-      "badge": "The Shift",
-      "title": "Computing as a Service",
-      "intro": "The future isn't better video calls. It's shared context.",
+      "badge": "What's Next",
+      "title": "Where We're Headed",
+      "intro": "We're building toward:",
       "future": [
-        "Ephemeral Environments: Spin up, solve the problem, destroy the evidence.",
-        "AI Co-workers: Agents that live in your desktop, not just a chat window.",
-        "Universal Access: Your powerful dev machine is a URL—with native touch gestures on mobile.",
-        "Default Multiplayer: Collaboration is baked into the kernel of how we work."
+        "Ephemeral environments you spin up and throw away",
+        "AI agents that operate inside your desktop, not just a chat box",
+        "Full desktop access from any device, including mobile with native touch",
+        "Multiplayer as the default, not an add-on"
       ]
     },
     "cta": {
-      "title": "See It Yourself",
-      "description": "We offer a free tier. No credit card. Spin up a session, invite a teammate, and experience what actual real-time collaboration feels like.",
+      "title": "Try It",
+      "description": "Free tier. No credit card. Spin up a session and invite a teammate.",
       "button": "Try Cyqle Free"
     }
   },

--- a/i18n/messages/es/index.json
+++ b/i18n/messages/es/index.json
@@ -255,84 +255,82 @@
   },
   "aboutPage": {
     "hero": {
-      "title": "¿Quién dijo que la rueda no se puede reinventar?",
-      "subtitle": "La vieja no fue construida para la nube."
+      "title": "Un Escritorio Cloud Multijugador",
+      "subtitle": "Misma máquina. Múltiples teclados. Todos manejan."
     },
     "problem": {
-      "badge": "La Fricción",
-      "title": "La Colaboración se Quedó en los 90",
-      "intro": "El código vive en la nube. Los datos viven en la nube. ¿Pero tu entorno de trabajo? Sigue atrapado en tu dispositivo local.",
-      "scenario1": "Compartir pantalla es pasivo. Un conductor, muchos pasajeros. No es colaboración; es una presentación. No puedes arreglar un bug que no puedes tocar.",
-      "scenario2": "Los entornos locales son frágiles. Pasas horas configurando un espacio de trabajo que desaparece al cerrar la laptop. Compartirlo significa explicar pasos, no enviar un link.",
-      "scenario3": "El cómputo está disperso. Tu equipo tiene 10 laptops potentes pero ninguna infraestructura compartida para atacar un problema juntos.",
-      "truth": "Nos preguntamos: ¿Qué pasaría si el sistema operativo fuera multijugador? ¿Y si pudieras compartir una computadora completa con un link, como un Google Doc?",
-      "solution": "Cyqle es la respuesta."
+      "badge": "El Problema",
+      "title": "El Trabajo Remoto Sigue Siendo por Turnos",
+      "intro": "Compartir pantalla es un conductor y muchos espectadores. Eso no es colaborar.",
+      "scenario1": "No podés tocar el código en la pantalla compartida de otro. Solo mirás y describís qué tipear.",
+      "scenario2": "Los entornos locales se rompen, divergen, y no se comparten con un link.",
+      "scenario3": "Tu equipo tiene 10 laptops pero ninguna máquina compartida para trabajar juntos.",
+      "truth": "Los sistemas operativos fueron hechos para un usuario. Nosotros hicimos uno para muchos.",
+      "solution": "Eso es Cyqle."
     },
     "story": {
-      "badge": "Nuestra Lógica",
-      "title": "¿Por Qué Construimos Esto?",
-      "year2017": "Empezamos construyendo herramientas de automatización de navegadores. Útiles, pero limitadas. Nos dimos cuenta de que automatizar un navegador solo resolvía el 10% del problema.",
-      "pivot": "El verdadero cuello de botella era el Sistema Operativo.",
-      "year2025": "Los sistemas operativos, en esencia, están orientados a un único usuario final. Por eso compartir pantalla es tan doloroso—es un parche sobre una arquitectura para un solo jugador.",
-      "realization": "Decidimos reconstruir el stack de escritorio para colaboración P2P. Sin 'host' ni 'invitado'—solo usuarios iguales trabajando en paralelo en la misma máquina.",
-      "present": "Cyqle es el resultado: Una computadora en la nube que trata la colaboración como una primitiva, no como una funcionalidad extra."
+      "badge": "Contexto",
+      "title": "Cómo Llegamos Acá",
+      "year2017": "Empezamos en automatización de navegadores. Útil, pero solo resolvía parte del problema.",
+      "pivot": "El cuello de botella era el SO — hecho para un solo usuario.",
+      "year2025": "Compartir pantalla es un parche sobre arquitectura single-player. Por eso duele.",
+      "realization": "Así que reconstruimos el escritorio para P2P. Sin host ni invitado — solo usuarios iguales en la misma máquina.",
+      "present": "Cyqle es una computadora cloud donde la colaboración es una primitiva central."
     },
     "solution": {
-      "badge": "Qué es realmente",
-      "title": "Un escritorio Linux completo que no desaparece",
-      "paragraph1": "Cyqle es un entorno Linux real en la nube. Pero en lugar de que uno maneje y los demás miren, todos trabajan al mismo tiempo. Varias personas escribiendo en paralelo, cada una con su cursor y ventana.",
-      "paragraph2": "No es compartir pantalla. No es una VM a la que te conectas por SSH. Es una computadora realmente multijugador que arrancas en segundos, colaboras en vivo, después cerrás—o guardas y retomas desde donde sea.",
+      "badge": "Qué Es",
+      "title": "Un Escritorio Linux Completo, Compartido en Tiempo Real",
+      "paragraph1": "Cyqle es un entorno Linux real en la nube. Varias personas trabajan simultáneamente, cada una con su propio cursor y teclado.",
+      "paragraph2": "No es compartir pantalla. No es una VM por SSH. Es una computadora multijugador que arrancás en segundos, trabajás en equipo, y cerrás o persistís.",
       "realityCheck": "Se acabó:",
       "painPoints": [
-        "\"¿Ven mi pantalla?\" (ya están ahí)",
-        "Describir errores por chat (mejor invítalos)",
-        "\"En mi máquina funciona\" (usen la misma máquina)",
-        "Reconstruir ambientes de demo (hacé snapshots y reutilizalos)",
-        "Escribir scripts para tareas simples (grabalo y listo)"
+        "\"¿Ven mi pantalla?\" — ya están ahí",
+        "Describir bugs por chat — invitalos directo",
+        "\"En mi máquina funciona\" — usen la misma máquina",
+        "Reconstruir ambientes de demo — snapshot y reusar",
+        "Escribir scripts para tareas simples — grabar y repetir"
       ]
     },
     "difference": {
       "badge": "Bajo el Capó",
-      "title": "Ingeniería Compleja, Invisible para Ti",
-      "intro": "Resolvimos los problemas que hicieron imposibles los escritorios en la nube en tiempo real durante años:",
+      "title": "Lo Que Tuvimos Que Resolver",
+      "intro": "Los escritorios cloud en tiempo real requieren resolver problemas difíciles:",
       "challenges": [
-        "Streaming P2P de latencia cero (sin lag de servidor central)",
+        "Streaming P2P con latencia mínima (sin relay central)",
         "Inyección de input multi-cursor a nivel de sistema",
-        "Almacenamiento efímero garantizado criptográficamente",
-        "Aprovisionamiento instantáneo (arranque en menos de 5 segundos)",
-        "Acceso vía navegador con rendimiento nativo"
+        "Almacenamiento efímero criptográficamente borrable",
+        "Arranque en menos de 5 segundos",
+        "Acceso por navegador con rendimiento nativo"
       ],
-      "conclusion": "Es tecnología compleja envolviendo una promesa simple: Simplemente funciona."
+      "conclusion": "Infraestructura compleja detrás de una experiencia simple."
     },
     "forWhom": {
       "badge": "Casos de Uso",
       "title": "Construido para Equipos que:",
       "items": [
-        "Depuran juntos, no secuencialmente",
-        "Necesitan entornos de reproducción instantáneos y descartables",
-        "Quieren hacer onboarding haciendo, no documentando",
-        "Corren automatización de navegadores sin mantener infraestructura",
-        "Odian el lag y la fricción de compartir pantalla",
-        "Necesitan un sandbox seguro para probar agentes de IA",
-        "Requieren acceso root sin comprometer la seguridad local",
-        "Valoran el estado de flujo sobre el tiempo de configuración"
+        "Depuran juntos en vez de turnarse",
+        "Necesitan entornos de reproducción descartables",
+        "Hacen onboarding práctico, no con documentación",
+        "Corren automatización de navegadores sin infra propia",
+        "Necesitan un sandbox seguro para agentes de IA",
+        "Quieren acceso root sin arriesgar máquinas locales"
       ]
     },
     "vision": {
-      "badge": "El Cambio",
-      "title": "Computación como Servicio",
-      "intro": "El futuro no son mejores videollamadas. Es contexto compartido.",
+      "badge": "Lo Que Viene",
+      "title": "Hacia Dónde Vamos",
+      "intro": "Estamos construyendo hacia:",
       "future": [
-        "Entornos Efímeros: Levanta, resuelve el problema, destruye la evidencia.",
-        "Compañeros IA: Agentes que viven en tu escritorio, no solo en una ventana de chat.",
-        "Acceso Universal: Tu potente máquina de desarrollo es una URL—con gestos táctiles nativos en el celular.",
-        "Multijugador por Defecto: La colaboración está integrada en el kernel de cómo trabajamos."
+        "Entornos efímeros que levantás y descartás",
+        "Agentes de IA que operan dentro de tu escritorio, no solo en un chat",
+        "Acceso completo al escritorio desde cualquier dispositivo, incluyendo móvil con touch nativo",
+        "Multijugador como default, no como agregado"
       ]
     },
     "cta": {
-      "title": "Probalo vos mismo",
-      "description": "Hay un plan gratis. Sin tarjeta. Arrancá una sesión, invita a alguien del equipo y experimentá cómo se siente colaborar en tiempo real de verdad.",
-      "button": "Probar Cyqle gratis"
+      "title": "Probalo",
+      "description": "Plan gratis. Sin tarjeta. Arrancá una sesión e invitá a alguien.",
+      "button": "Probar Cyqle Gratis"
     }
   },
   "privacyPolicy": {


### PR DESCRIPTION
Rewrote all About Us copy (EN + ES) to be shorter and more direct.
Removed marketing-speak, tightened every section, reduced forWhom
list from 8 to 6 items, and shortened SEO meta descriptions.

https://claude.ai/code/session_01QCH2AhybPGqBEriWifZyG7