### PR TITLE
Control line breaks in Spanish hero title

### DIFF
--- a/i18n/messages/es/index.json
+++ b/i18n/messages/es/index.json
@@ -14,7 +14,7 @@
     "changeLanguage": "Cambiar idioma"
   },
   "hero": {
-    "title": "Un Escritorio Cloud que Podés Compartir de Verdad",
+    "title": "Un Escritorio Cloud que Podés Compartir de Verdad",
     "titlePhrase1": "Tu Escritorio Cloud",
     "titlePhrase2": "Tu Espacio de Trabajo Compartido",
     "titlePhrase3": "La Computadora de tu Equipo",


### PR DESCRIPTION
## Summary

The Spanish hero title wrapped mid-phrase on mobile:

> Un Escritorio /
> Cloud que Podés /
> Compartir de Verdad

This PR keeps the full title but inserts non-breaking spaces inside each semantic unit, so the browser can only break between them. Phones now render:

> Un Escritorio Cloud
> que Podés Compartir
> de Verdad

and desktop settles into two balanced lines ("Un Escritorio Cloud / que Podés Compartir de Verdad").

## Verification

Rendered `/es` with Playwright at 360px, 320px, and 1440px viewports — line breaks land only on the semantic units and there is no horizontal overflow at any width. Line widths were measured against the real h1 font (Inter 700 30px) to confirm each unit fits the 328px mobile container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmJPDDWNtUfNL2qsKP22EG

---
_Generated by [Claude Code](https://claude.ai/code/session_01UmJPDDWNtUfNL2qsKP22EG)_